### PR TITLE
Use fixedpoint inference for cyclic file import checking

### DIFF
--- a/crates/cli/src/check.rs
+++ b/crates/cli/src/check.rs
@@ -526,7 +526,7 @@ pub fn run_check_project(
             // Clone bundles for reuse across rounds. Metadata is extracted
             // once and held aside — only the final round's diagnostics are
             // kept.
-            tracing::info!(
+            tracing::debug!(
                 "layer {}: cyclic SCC with {} files, up to {} fixpoint rounds",
                 layer_idx,
                 scc.files.len(),
@@ -604,7 +604,7 @@ pub fn run_check_project(
                 });
 
                 if converged {
-                    tracing::info!(
+                    tracing::debug!(
                         "cyclic SCC ({} files) converged after {} round(s)",
                         scc.files.len(),
                         round + 1,

--- a/crates/cli/src/check.rs
+++ b/crates/cli/src/check.rs
@@ -85,6 +85,62 @@ struct RenderableResult {
     ignore_lines: std::collections::HashSet<u32>,
 }
 
+/// Intermediate result from inference (before combining with metadata for rendering).
+struct InferBundleResult {
+    diagnostics: Vec<lang_check::diagnostic::TixDiagnostic>,
+    nocheck: bool,
+    ignore_lines: std::collections::HashSet<u32>,
+    bailed_out: bool,
+}
+
+/// Infer a file from a pre-extracted SyntaxBundle and cache its signature.
+/// Shared by both the single-pass path and fixpoint iteration.
+fn infer_bundle(
+    coordinator: &InferenceCoordinator,
+    file_path: &Path,
+    bundle: SyntaxBundle,
+) -> InferBundleResult {
+    let base_dir = file_path.parent().unwrap_or(Path::new("/"));
+
+    let import_resolution = coordinator.resolve_imports(
+        &bundle.module,
+        &bundle.name_res,
+        base_dir,
+        Some(&bundle.registry),
+    );
+    let import_diagnostics =
+        lang_check::imports::import_errors_to_diagnostics(&import_resolution.errors);
+
+    let inputs = lang_check::InferenceInputs {
+        module: bundle.module,
+        module_indices: bundle.module_indices,
+        name_res: bundle.name_res,
+        grouped_defs: bundle.grouped_defs,
+        registry: bundle.registry,
+        import_types: import_resolution.types,
+        import_diagnostics,
+        context_args: bundle.context_args,
+        rss_limit_mb: None,
+        file_path: Some(file_path.to_path_buf()),
+        imported_type_exports: std::collections::HashMap::new(),
+        typeof_import_types: std::collections::HashMap::new(),
+        file_base_dir: None,
+    };
+
+    let check_result = lang_check::run_inference(&inputs);
+
+    if let Some(sig) = lang_check::extract_file_signature(&check_result, inputs.module.entry_expr) {
+        coordinator.set_signature(file_path, sig);
+    }
+
+    InferBundleResult {
+        diagnostics: check_result.diagnostics,
+        nocheck: inputs.module.nocheck,
+        ignore_lines: inputs.module.ignore_lines.clone(),
+        bailed_out: check_result.bailed_out,
+    }
+}
+
 /// Entry point for `tix check`.
 pub fn run_check_project(
     config_path: Option<PathBuf>,
@@ -326,7 +382,7 @@ pub fn run_check_project(
     // Each subsequent layer's dependencies are guaranteed to be cached from
     // prior layers.
 
-    let layers = lang_check::file_graph::build_file_layers(&import_edges);
+    let layers = lang_check::file_graph::build_file_layers_with_sccs(&import_edges);
     let mut importer_counts = lang_check::file_graph::compute_importer_counts(&import_edges);
     timer.mark("dependency graph");
 
@@ -336,31 +392,30 @@ pub fn run_check_project(
     // Phase 2 — Layered Parallel Inference with cross-file type flow
     // =========================================================================
     //
-    // Files are inferred layer-by-layer. Within each layer, files run in
-    // parallel via rayon. Dependencies from prior layers have their signatures
-    // cached in the coordinator, so import resolution gets real types instead
-    // of ⊤.
+    // Files are inferred layer-by-layer, SCC-by-SCC within each layer.
+    // Dependencies from prior layers have their signatures cached in the
+    // coordinator, so import resolution gets real types instead of ⊤.
+    //
+    // Non-cyclic SCCs (single files) are inferred once. Cyclic SCCs (mutual
+    // imports) are iterated until signatures stabilize or the iteration cap
+    // is reached, giving real types across cycle edges.
     //
     // Memory optimization: reference-counted eviction drops signatures whose
     // importers have all been processed, keeping the live set bounded to the
     // "frontier" rather than the entire project.
-    //
-    // Files within the same SCC layer get ⊤ for intra-SCC imports (their
-    // signatures aren't cached yet when peers run in parallel). All acyclic
-    // imports get real types.
 
     // Files with more than this many expressions run sequentially within their
     // layer to avoid concurrent memory spikes that cause OOM on large projects.
-    // 20K catches all known problematic files (hackage-packages.nix at 657K,
-    // perl-packages.nix at 154K, r-modules/default.nix at 47K) while staying
-    // well above typical file sizes (~100-1K exprs).
     const HEAVY_FILE_EXPR_THRESHOLD: usize = 20_000;
+    /// Maximum fixpoint iterations for cyclic SCCs. Most cycles converge in
+    /// 2-3 rounds; 4 is a conservative cap.
+    const MAX_FIXPOINT_ROUNDS: usize = 4;
 
     let coordinator = InferenceCoordinator::new();
     let mut all_results: Vec<RenderableResult> = Vec::with_capacity(files_count);
 
-    // Shared inference logic for a single file. Used by both the sequential
-    // (heavy) and parallel (light) paths.
+    // Shared inference logic for a single file. Consumes the bundle from the
+    // syntax provider and metadata from the metadata map.
     let infer_one = |path: &PathBuf| -> Option<RenderableResult> {
         let (file_path, fm) = metadata_map.remove(path)?;
 
@@ -372,7 +427,6 @@ pub fn run_check_project(
             "starting file"
         );
 
-        // Consume the pre-extracted SyntaxBundle from the DashMap.
         let bundle = match syntax_provider.syntax_for_file(&file_path) {
             Some(b) => b,
             None => {
@@ -387,114 +441,179 @@ pub fn run_check_project(
             }
         };
 
-        let base_dir = file_path.parent().unwrap_or(std::path::Path::new("/"));
-
-        // Resolve imports from the coordinator cache. Prior layers'
-        // signatures are available; intra-SCC imports get ⊤.
-        let import_resolution = coordinator.resolve_imports(
-            &bundle.module,
-            &bundle.name_res,
-            base_dir,
-            Some(&bundle.registry),
-        );
-        let import_diagnostics =
-            lang_check::imports::import_errors_to_diagnostics(&import_resolution.errors);
-
-        // Build InferenceInputs and run inference.
-        let inputs = lang_check::InferenceInputs {
-            module: bundle.module,
-            module_indices: bundle.module_indices,
-            name_res: bundle.name_res,
-            grouped_defs: bundle.grouped_defs,
-            registry: bundle.registry,
-            import_types: import_resolution.types,
-            import_diagnostics,
-            context_args: bundle.context_args,
-            rss_limit_mb: None,
-            file_path: Some(file_path.clone()),
-            imported_type_exports: std::collections::HashMap::new(),
-            typeof_import_types: std::collections::HashMap::new(),
-            file_base_dir: None,
-        };
-
-        let check_result = lang_check::run_inference(&inputs);
-
-        // Cache this file's signature for subsequent layers.
-        if let Some(sig) =
-            lang_check::extract_file_signature(&check_result, inputs.module.entry_expr)
-        {
-            coordinator.set_signature(&file_path, sig);
-        }
+        let result = infer_bundle(&coordinator, &file_path, bundle);
 
         tracing::debug!(
             file = %lang_ast::display_path(&file_path),
             rss_mb = format_args!("{:.0}", lang_check::rss_mb()),
-            diags = check_result.diagnostics.len(),
-            bailed_out = check_result.bailed_out,
+            diags = result.diagnostics.len(),
+            bailed_out = result.bailed_out,
             "finished file"
         );
 
-        let nocheck = inputs.module.nocheck;
-        let ignore_lines = inputs.module.ignore_lines.clone();
-
-        // Extract only diagnostics. The heavy InferenceResult is dropped
-        // here, keeping memory bounded.
         Some(RenderableResult {
             file_path,
             source_text: fm.source_text,
             source_map: fm.source_map,
-            diagnostics: check_result.diagnostics,
-            nocheck,
-            ignore_lines,
+            diagnostics: result.diagnostics,
+            nocheck: result.nocheck,
+            ignore_lines: result.ignore_lines,
         })
     };
 
     for (layer_idx, layer) in layers.iter().enumerate() {
+        let layer_file_count: usize = layer.sccs.iter().map(|s| s.files.len()).sum();
         tracing::debug!(
             layer = layer_idx,
-            files = layer.len(),
+            files = layer_file_count,
+            sccs = layer.sccs.len(),
             rss_mb = format_args!("{:.0}", lang_check::rss_mb()),
             "starting layer"
         );
 
-        // Partition into heavy files (run sequentially to bound memory) and
-        // light files (run in parallel as before).
-        let (heavy, light): (Vec<_>, Vec<_>) = layer
-            .iter()
-            .partition(|p| expr_counts.get(*p).copied().unwrap_or(0) > HEAVY_FILE_EXPR_THRESHOLD);
+        for scc in &layer.sccs {
+            if !scc.is_cyclic {
+                // =============================================================
+                // Non-cyclic SCC: single-pass inference (unchanged behavior)
+                // =============================================================
+                let (heavy, light): (Vec<_>, Vec<_>) = scc.files.iter().partition(|p| {
+                    expr_counts.get(*p).copied().unwrap_or(0) > HEAVY_FILE_EXPR_THRESHOLD
+                });
 
-        if !heavy.is_empty() {
-            tracing::info!(
-                "layer has {} heavy file(s) (>{} exprs), running sequentially: {}",
-                heavy.len(),
-                HEAVY_FILE_EXPR_THRESHOLD,
-                heavy
+                if !heavy.is_empty() {
+                    tracing::info!(
+                        "layer {} has {} heavy file(s) (>{} exprs), running sequentially: {}",
+                        layer_idx,
+                        heavy.len(),
+                        HEAVY_FILE_EXPR_THRESHOLD,
+                        heavy
+                            .iter()
+                            .map(|p| format!(
+                                "{} ({})",
+                                p.file_name().unwrap_or_default().to_string_lossy(),
+                                expr_counts.get(*p).unwrap_or(&0)
+                            ))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                }
+
+                let heavy_results: Vec<RenderableResult> =
+                    heavy.iter().filter_map(|p| infer_one(p)).collect();
+                let light_results: Vec<RenderableResult> =
+                    light.par_iter().filter_map(|p| infer_one(p)).collect();
+
+                all_results.extend(heavy_results);
+                all_results.extend(light_results);
+            } else {
+                // =============================================================
+                // Cyclic SCC: fixpoint iteration
+                // =============================================================
+                //
+                // Clone bundles for reuse across rounds. Metadata is extracted
+                // once and held aside — only the final round's diagnostics are
+                // kept.
+                tracing::info!(
+                    "layer {}: cyclic SCC with {} files, up to {} fixpoint rounds",
+                    layer_idx,
+                    scc.files.len(),
+                    MAX_FIXPOINT_ROUNDS,
+                );
+
+                // Pre-extract bundles (clone for reuse) and metadata.
+                let scc_bundles: HashMap<PathBuf, SyntaxBundle> = scc
+                    .files
                     .iter()
-                    .map(|p| format!(
-                        "{} ({})",
-                        p.file_name().unwrap_or_default().to_string_lossy(),
-                        expr_counts.get(*p).unwrap_or(&0)
-                    ))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
+                    .filter_map(|p| {
+                        syntax_provider
+                            .precomputed
+                            .get(p)
+                            .map(|entry| (p.clone(), entry.value().clone()))
+                    })
+                    .collect();
+
+                let scc_metadata: HashMap<PathBuf, FileMetadata> = scc
+                    .files
+                    .iter()
+                    .filter_map(|p| metadata_map.remove(p))
+                    .collect();
+
+                let mut last_results: Vec<RenderableResult> = Vec::new();
+
+                for round in 0..MAX_FIXPOINT_ROUNDS {
+                    // Snapshot signatures before this round for convergence check.
+                    let prev_sigs: HashMap<PathBuf, Option<lang_ty::OwnedTy>> = scc
+                        .files
+                        .iter()
+                        .map(|p| (p.clone(), coordinator.get_signature(p)))
+                        .collect();
+
+                    last_results.clear();
+
+                    // Infer all files in the SCC sequentially within each round.
+                    // Sequential ensures deterministic convergence: each file in
+                    // round N sees all of round N-1's signatures (Jacobi-style
+                    // within a round, since we snapshot above).
+                    for path in &scc.files {
+                        let Some(bundle) = scc_bundles.get(path).cloned() else {
+                            continue;
+                        };
+
+                        let file_path = path.clone();
+                        let result = infer_bundle(&coordinator, &file_path, bundle);
+
+                        if let Some(fm) = scc_metadata.get(path) {
+                            last_results.push(RenderableResult {
+                                file_path,
+                                source_text: fm.source_text.clone(),
+                                source_map: fm.source_map.clone(),
+                                diagnostics: result.diagnostics,
+                                nocheck: result.nocheck,
+                                ignore_lines: result.ignore_lines,
+                            });
+                        }
+                    }
+
+                    // Skip convergence check on the first round — there are no
+                    // previous signatures to compare against.
+                    if round == 0 {
+                        continue;
+                    }
+
+                    // Check convergence: all signatures structurally unchanged.
+                    let converged = scc.files.iter().all(|p| {
+                        let new_sig = coordinator.get_signature(p);
+                        match (&prev_sigs[p], &new_sig) {
+                            (Some(old), Some(new)) => old.structurally_eq(new),
+                            (None, None) => true,
+                            _ => false,
+                        }
+                    });
+
+                    if converged {
+                        tracing::info!(
+                            "cyclic SCC ({} files) converged after {} round(s)",
+                            scc.files.len(),
+                            round + 1,
+                        );
+                        break;
+                    }
+                }
+
+                // Remove consumed bundles from the syntax provider.
+                for path in &scc.files {
+                    syntax_provider.precomputed.remove(path);
+                }
+
+                all_results.extend(last_results);
+            }
         }
-
-        // Heavy files first (sequential) — frees their memory before light files start.
-        let heavy_results: Vec<RenderableResult> =
-            heavy.iter().filter_map(|p| infer_one(p)).collect();
-        // Light files (parallel).
-        let light_results: Vec<RenderableResult> =
-            light.par_iter().filter_map(|p| infer_one(p)).collect();
-
-        all_results.extend(heavy_results);
-        all_results.extend(light_results);
 
         // Reference-counted eviction: decrement importer counts for each
         // dependency of files in this layer. Evict signatures whose count
         // reaches 0 (all importers have been processed).
         let mut to_evict = Vec::new();
-        for file in layer {
+        for file in layer.all_files() {
             if let Some(deps) = import_edges.get(file) {
                 for dep in deps {
                     if let Some(count) = importer_counts.get_mut(dep) {

--- a/crates/cli/src/check.rs
+++ b/crates/cli/src/check.rs
@@ -471,142 +471,154 @@ pub fn run_check_project(
             "starting layer"
         );
 
-        for scc in &layer.sccs {
-            if !scc.is_cyclic {
-                // =============================================================
-                // Non-cyclic SCC: single-pass inference (unchanged behavior)
-                // =============================================================
-                let (heavy, light): (Vec<_>, Vec<_>) = scc.files.iter().partition(|p| {
+        // =================================================================
+        // Non-cyclic files: batch all singletons across SCCs for parallel
+        // inference, preserving the original par_iter parallelism.
+        // =================================================================
+        let non_cyclic_files: Vec<&PathBuf> = layer
+            .sccs
+            .iter()
+            .filter(|scc| !scc.is_cyclic)
+            .flat_map(|scc| scc.files.iter())
+            .collect();
+
+        if !non_cyclic_files.is_empty() {
+            let (heavy, light): (Vec<&PathBuf>, Vec<&PathBuf>) =
+                non_cyclic_files.into_iter().partition(|p| {
                     expr_counts.get(*p).copied().unwrap_or(0) > HEAVY_FILE_EXPR_THRESHOLD
                 });
 
-                if !heavy.is_empty() {
-                    tracing::info!(
-                        "layer {} has {} heavy file(s) (>{} exprs), running sequentially: {}",
-                        layer_idx,
-                        heavy.len(),
-                        HEAVY_FILE_EXPR_THRESHOLD,
-                        heavy
-                            .iter()
-                            .map(|p| format!(
-                                "{} ({})",
-                                p.file_name().unwrap_or_default().to_string_lossy(),
-                                expr_counts.get(*p).unwrap_or(&0)
-                            ))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    );
-                }
-
-                let heavy_results: Vec<RenderableResult> =
-                    heavy.iter().filter_map(|p| infer_one(p)).collect();
-                let light_results: Vec<RenderableResult> =
-                    light.par_iter().filter_map(|p| infer_one(p)).collect();
-
-                all_results.extend(heavy_results);
-                all_results.extend(light_results);
-            } else {
-                // =============================================================
-                // Cyclic SCC: fixpoint iteration
-                // =============================================================
-                //
-                // Clone bundles for reuse across rounds. Metadata is extracted
-                // once and held aside — only the final round's diagnostics are
-                // kept.
+            if !heavy.is_empty() {
                 tracing::info!(
-                    "layer {}: cyclic SCC with {} files, up to {} fixpoint rounds",
+                    "layer {} has {} heavy file(s) (>{} exprs), running sequentially: {}",
                     layer_idx,
-                    scc.files.len(),
-                    MAX_FIXPOINT_ROUNDS,
-                );
-
-                // Pre-extract bundles (clone for reuse) and metadata.
-                let scc_bundles: HashMap<PathBuf, SyntaxBundle> = scc
-                    .files
-                    .iter()
-                    .filter_map(|p| {
-                        syntax_provider
-                            .precomputed
-                            .get(p)
-                            .map(|entry| (p.clone(), entry.value().clone()))
-                    })
-                    .collect();
-
-                let scc_metadata: HashMap<PathBuf, FileMetadata> = scc
-                    .files
-                    .iter()
-                    .filter_map(|p| metadata_map.remove(p))
-                    .collect();
-
-                let mut last_results: Vec<RenderableResult> = Vec::new();
-
-                for round in 0..MAX_FIXPOINT_ROUNDS {
-                    // Snapshot signatures before this round for convergence check.
-                    let prev_sigs: HashMap<PathBuf, Option<lang_ty::OwnedTy>> = scc
-                        .files
+                    heavy.len(),
+                    HEAVY_FILE_EXPR_THRESHOLD,
+                    heavy
                         .iter()
-                        .map(|p| (p.clone(), coordinator.get_signature(p)))
-                        .collect();
-
-                    last_results.clear();
-
-                    // Infer all files in the SCC sequentially within each round.
-                    // Sequential ensures deterministic convergence: each file in
-                    // round N sees all of round N-1's signatures (Jacobi-style
-                    // within a round, since we snapshot above).
-                    for path in &scc.files {
-                        let Some(bundle) = scc_bundles.get(path).cloned() else {
-                            continue;
-                        };
-
-                        let file_path = path.clone();
-                        let result = infer_bundle(&coordinator, &file_path, bundle);
-
-                        if let Some(fm) = scc_metadata.get(path) {
-                            last_results.push(RenderableResult {
-                                file_path,
-                                source_text: fm.source_text.clone(),
-                                source_map: fm.source_map.clone(),
-                                diagnostics: result.diagnostics,
-                                nocheck: result.nocheck,
-                                ignore_lines: result.ignore_lines,
-                            });
-                        }
-                    }
-
-                    // Skip convergence check on the first round — there are no
-                    // previous signatures to compare against.
-                    if round == 0 {
-                        continue;
-                    }
-
-                    // Check convergence: all signatures structurally unchanged.
-                    let converged = scc.files.iter().all(|p| {
-                        let new_sig = coordinator.get_signature(p);
-                        match (&prev_sigs[p], &new_sig) {
-                            (Some(old), Some(new)) => old.structurally_eq(new),
-                            (None, None) => true,
-                            _ => false,
-                        }
-                    });
-
-                    if converged {
-                        tracing::info!(
-                            "cyclic SCC ({} files) converged after {} round(s)",
-                            scc.files.len(),
-                            round + 1,
-                        );
-                        break;
-                    }
-                }
-
-                // Remove consumed bundles from the syntax provider.
-                for path in &scc.files {
-                    syntax_provider.precomputed.remove(path);
-                }
-
-                all_results.extend(last_results);
+                        .map(|p| format!(
+                            "{} ({})",
+                            p.file_name().unwrap_or_default().to_string_lossy(),
+                            expr_counts.get(*p).unwrap_or(&0)
+                        ))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
             }
+
+            let heavy_results: Vec<RenderableResult> =
+                heavy.iter().filter_map(|p| infer_one(p)).collect();
+            let light_results: Vec<RenderableResult> =
+                light.par_iter().filter_map(|p| infer_one(p)).collect();
+
+            all_results.extend(heavy_results);
+            all_results.extend(light_results);
+        }
+
+        // =================================================================
+        // Cyclic SCCs: fixpoint iteration (sequential within each SCC)
+        // =================================================================
+        for scc in layer.sccs.iter().filter(|scc| scc.is_cyclic) {
+            // =============================================================
+            // Cyclic SCC: fixpoint iteration
+            // =============================================================
+            //
+            // Clone bundles for reuse across rounds. Metadata is extracted
+            // once and held aside — only the final round's diagnostics are
+            // kept.
+            tracing::info!(
+                "layer {}: cyclic SCC with {} files, up to {} fixpoint rounds",
+                layer_idx,
+                scc.files.len(),
+                MAX_FIXPOINT_ROUNDS,
+            );
+
+            // Pre-extract bundles (clone for reuse) and metadata.
+            let scc_bundles: HashMap<PathBuf, SyntaxBundle> = scc
+                .files
+                .iter()
+                .filter_map(|p| {
+                    syntax_provider
+                        .precomputed
+                        .get(p)
+                        .map(|entry| (p.clone(), entry.value().clone()))
+                })
+                .collect();
+
+            let scc_metadata: HashMap<PathBuf, FileMetadata> = scc
+                .files
+                .iter()
+                .filter_map(|p| metadata_map.remove(p))
+                .collect();
+
+            let mut last_results: Vec<RenderableResult> = Vec::new();
+
+            for round in 0..MAX_FIXPOINT_ROUNDS {
+                // Snapshot signatures before this round for convergence check.
+                let prev_sigs: HashMap<PathBuf, Option<lang_ty::OwnedTy>> = scc
+                    .files
+                    .iter()
+                    .map(|p| (p.clone(), coordinator.get_signature(p)))
+                    .collect();
+
+                last_results.clear();
+
+                // Infer all files in the SCC sequentially within each round.
+                // Sequential ensures deterministic convergence: each file in
+                // round N sees all of round N-1's signatures (Jacobi-style
+                // within a round, since we snapshot above).
+                for path in &scc.files {
+                    let Some(bundle) = scc_bundles.get(path).cloned() else {
+                        continue;
+                    };
+
+                    let file_path = path.clone();
+                    let result = infer_bundle(&coordinator, &file_path, bundle);
+
+                    if let Some(fm) = scc_metadata.get(path) {
+                        last_results.push(RenderableResult {
+                            file_path,
+                            source_text: fm.source_text.clone(),
+                            source_map: fm.source_map.clone(),
+                            diagnostics: result.diagnostics,
+                            nocheck: result.nocheck,
+                            ignore_lines: result.ignore_lines,
+                        });
+                    }
+                }
+
+                // Skip convergence check on the first round — there are no
+                // previous signatures to compare against.
+                if round == 0 {
+                    continue;
+                }
+
+                // Check convergence: all signatures structurally unchanged.
+                let converged = scc.files.iter().all(|p| {
+                    let new_sig = coordinator.get_signature(p);
+                    match (&prev_sigs[p], &new_sig) {
+                        (Some(old), Some(new)) => old.structurally_eq(new),
+                        (None, None) => true,
+                        _ => false,
+                    }
+                });
+
+                if converged {
+                    tracing::info!(
+                        "cyclic SCC ({} files) converged after {} round(s)",
+                        scc.files.len(),
+                        round + 1,
+                    );
+                    break;
+                }
+            }
+
+            // Remove consumed bundles from the syntax provider.
+            for path in &scc.files {
+                syntax_provider.precomputed.remove(path);
+            }
+
+            all_results.extend(last_results);
         }
 
         // Reference-counted eviction: decrement importer counts for each

--- a/crates/lang_check/src/coordinator.rs
+++ b/crates/lang_check/src/coordinator.rs
@@ -496,12 +496,15 @@ impl InferenceCoordinator {
     /// Store a file's signature in the cache (passive mode).
     /// Returns `true` if the signature changed (callers use this to decide
     /// whether to trigger dependent re-analysis).
+    ///
+    /// Uses structural equality (not identity) so that re-inferring a file
+    /// with the same result doesn't trigger cascading re-analysis.
     pub fn set_signature(&self, path: &Path, sig: FileSignature) -> bool {
         let changed = self
             .cache
             .get(path)
             .map(|entry| match &*entry {
-                FileSlot::Ready(Some(existing)) => *existing != sig,
+                FileSlot::Ready(Some(existing)) => !existing.root_ty.structurally_eq(&sig.root_ty),
                 _ => true,
             })
             .unwrap_or(true);

--- a/crates/lang_check/src/diagnostic.rs
+++ b/crates/lang_check/src/diagnostic.rs
@@ -302,7 +302,7 @@ impl fmt::Display for TixDiagnosticKind {
             TixDiagnosticKind::ImportUnresolved { path } => {
                 write!(
                     f,
-                    "imported file `{path}` has not been analyzed — add it to [project] analyze in tix.toml or open it in the editor"
+                    "imported file `{path}` has not been analyzed — add it to [project] includes in tix.toml or open it in the editor"
                 )
             }
             TixDiagnosticKind::InvalidInterpolation { actual } => {

--- a/crates/lang_check/src/file_graph.rs
+++ b/crates/lang_check/src/file_graph.rs
@@ -18,6 +18,142 @@ use std::path::{Path, PathBuf};
 use petgraph::algo::{condensation, toposort};
 use petgraph::graph::{DiGraph, NodeIndex};
 
+/// A group of files forming a strongly connected component.
+pub struct SccGroup {
+    pub files: Vec<PathBuf>,
+    /// True if this SCC has >1 file (mutual imports) or a single file that
+    /// imports itself. Cyclic SCCs benefit from fixpoint iteration.
+    pub is_cyclic: bool,
+}
+
+/// A layer of SCCs at the same topological depth. All dependencies from
+/// prior layers are guaranteed to have cached signatures before this layer
+/// runs.
+pub struct InferenceLayer {
+    pub sccs: Vec<SccGroup>,
+}
+
+impl InferenceLayer {
+    /// Flat list of all files in this layer (convenience for eviction logic).
+    pub fn all_files(&self) -> impl Iterator<Item = &PathBuf> {
+        self.sccs.iter().flat_map(|scc| scc.files.iter())
+    }
+}
+
+/// Build inference layers preserving SCC grouping.
+///
+/// Like `build_file_layers`, but each layer contains a list of `SccGroup`s
+/// rather than a flat file list. This allows callers to identify which files
+/// are in non-trivial (cyclic) SCCs and apply fixpoint iteration to them.
+///
+/// O(V+E) overall — trivial for even 40K files.
+pub fn build_file_layers_with_sccs(
+    file_imports: &HashMap<PathBuf, Vec<PathBuf>>,
+) -> Vec<InferenceLayer> {
+    if file_imports.is_empty() {
+        return vec![];
+    }
+
+    // =========================================================================
+    // Step A: Build the raw file graph and condensation DAG
+    // =========================================================================
+
+    let mut graph: DiGraph<PathBuf, ()> = DiGraph::new();
+    let mut node_map: HashMap<&Path, NodeIndex> = HashMap::new();
+
+    for path in file_imports.keys() {
+        let idx = graph.add_node(path.clone());
+        node_map.insert(path.as_path(), idx);
+    }
+
+    // Track self-edges before condensation (condensation strips them).
+    let mut has_self_edge: std::collections::HashSet<NodeIndex> = std::collections::HashSet::new();
+
+    for (importer, deps) in file_imports {
+        let from = node_map[importer.as_path()];
+        for dep in deps {
+            if let Some(&to) = node_map.get(dep.as_path()) {
+                if from == to {
+                    has_self_edge.insert(from);
+                }
+                graph.add_edge(from, to, ());
+            }
+        }
+    }
+
+    // Map from original graph NodeIndex → condensed SCC NodeIndex so we can
+    // check self-edges on singleton SCCs.
+    let mut original_to_condensed: HashMap<NodeIndex, NodeIndex> = HashMap::new();
+
+    let condensed = condensation(graph, true);
+
+    // Build reverse mapping: for each condensed node, record which original
+    // nodes are members.
+    for cnode in condensed.node_indices() {
+        for original_path in &condensed[cnode] {
+            if let Some(&orig_idx) = node_map.get(original_path.as_path()) {
+                original_to_condensed.insert(orig_idx, cnode);
+            }
+        }
+    }
+
+    // =========================================================================
+    // Step B: Compute depth and group into layers (preserving SCC structure)
+    // =========================================================================
+
+    let topo_order = match toposort(&condensed, None) {
+        Ok(order) => order,
+        Err(_) => {
+            // Should never happen on a condensation DAG, but handle gracefully.
+            let all_files: Vec<PathBuf> = file_imports.keys().cloned().collect();
+            return vec![InferenceLayer {
+                sccs: vec![SccGroup {
+                    files: all_files,
+                    is_cyclic: true,
+                }],
+            }];
+        }
+    };
+
+    let mut depth: HashMap<NodeIndex, usize> = HashMap::with_capacity(topo_order.len());
+
+    for &node in topo_order.iter().rev() {
+        let max_dep_depth = condensed
+            .neighbors(node)
+            .filter_map(|succ| depth.get(&succ))
+            .max()
+            .copied();
+
+        let node_depth = match max_dep_depth {
+            Some(d) => d + 1,
+            None => 0,
+        };
+        depth.insert(node, node_depth);
+    }
+
+    let max_depth = depth.values().copied().max().unwrap_or(0);
+    let mut layers: Vec<InferenceLayer> = (0..=max_depth)
+        .map(|_| InferenceLayer { sccs: Vec::new() })
+        .collect();
+
+    for (&cnode, &d) in &depth {
+        let files: Vec<PathBuf> = condensed[cnode].to_vec();
+        let is_cyclic = if files.len() > 1 {
+            true
+        } else {
+            // Single-file SCC: cyclic only if it imports itself.
+            files
+                .first()
+                .and_then(|p| node_map.get(p.as_path()))
+                .is_some_and(|orig_idx| has_self_edge.contains(orig_idx))
+        };
+        layers[d].sccs.push(SccGroup { files, is_cyclic });
+    }
+
+    layers.retain(|l| !l.sccs.is_empty());
+    layers
+}
+
 /// Build inference layers from a file-level import graph.
 ///
 /// Input: map from canonical file path → list of its canonical import targets
@@ -30,92 +166,10 @@ use petgraph::graph::{DiGraph, NodeIndex};
 ///
 /// O(V+E) overall — trivial for even 40K files.
 pub fn build_file_layers(file_imports: &HashMap<PathBuf, Vec<PathBuf>>) -> Vec<Vec<PathBuf>> {
-    if file_imports.is_empty() {
-        return vec![];
-    }
-
-    // =========================================================================
-    // Step A: Build the raw file graph and condensation DAG
-    // =========================================================================
-
-    // Assign a graph node to every file that appears as a key in the import map.
-    let mut graph: DiGraph<PathBuf, ()> = DiGraph::new();
-    let mut node_map: HashMap<&Path, NodeIndex> = HashMap::new();
-
-    for path in file_imports.keys() {
-        let idx = graph.add_node(path.clone());
-        node_map.insert(path.as_path(), idx);
-    }
-
-    // Add edges: importer → dependency (only for in-project targets).
-    for (importer, deps) in file_imports {
-        let from = node_map[importer.as_path()];
-        for dep in deps {
-            if let Some(&to) = node_map.get(dep.as_path()) {
-                graph.add_edge(from, to, ());
-            }
-            // Imports to files outside the project set are silently dropped.
-        }
-    }
-
-    // Condensation: compute SCCs and build a DAG where each node is a
-    // Vec<PathBuf> containing the SCC's member files. `make_acyclic=true`
-    // strips self-loops and duplicate edges within the condensed graph.
-    let condensed = condensation(graph, true);
-
-    // =========================================================================
-    // Step B: Compute depth and group into layers
-    // =========================================================================
-    //
-    // Walk in topological order (leaves first). Each condensed node's depth is
-    // max(depth of successors) + 1 for nodes with outgoing edges, or 0 for
-    // leaf nodes. We then group by depth.
-    //
-    // Note: petgraph's condensation reverses the node order relative to the
-    // original graph, and edges point from SCCs to their dependencies. We
-    // compute depth based on successors (dependencies) so that leaves get
-    // depth 0 and roots get the highest depth.
-
-    let topo_order = match toposort(&condensed, None) {
-        Ok(order) => order,
-        Err(_) => {
-            // Should never happen on a condensation DAG, but handle gracefully:
-            // return all files in a single layer.
-            let all_files: Vec<PathBuf> = file_imports.keys().cloned().collect();
-            return vec![all_files];
-        }
-    };
-
-    let mut depth: HashMap<NodeIndex, usize> = HashMap::with_capacity(topo_order.len());
-
-    // Process in reverse topological order so that when we process a node,
-    // all its successors (dependencies) already have their depth computed.
-    for &node in topo_order.iter().rev() {
-        let max_dep_depth = condensed
-            .neighbors(node)
-            .filter_map(|succ| depth.get(&succ))
-            .max()
-            .copied();
-
-        let node_depth = match max_dep_depth {
-            Some(d) => d + 1,
-            None => 0, // Leaf node: no in-project dependencies.
-        };
-        depth.insert(node, node_depth);
-    }
-
-    // Group condensed nodes by depth, then expand each to its member files.
-    let max_depth = depth.values().copied().max().unwrap_or(0);
-    let mut layers: Vec<Vec<PathBuf>> = vec![Vec::new(); max_depth + 1];
-
-    for (&node, &d) in &depth {
-        layers[d].extend(condensed[node].iter().cloned());
-    }
-
-    // Remove any empty layers (shouldn't happen, but defensive).
-    layers.retain(|l| !l.is_empty());
-
-    layers
+    build_file_layers_with_sccs(file_imports)
+        .into_iter()
+        .map(|layer| layer.sccs.into_iter().flat_map(|scc| scc.files).collect())
+        .collect()
 }
 
 /// Compute importer counts for reference-counted eviction.
@@ -310,5 +364,117 @@ mod tests {
         assert_eq!(counts.get(&PathBuf::from("B")), Some(&1));
         // /external not counted (not in project set).
         assert_eq!(counts.get(&PathBuf::from("/external")), None);
+    }
+
+    // =========================================================================
+    // build_file_layers_with_sccs tests
+    // =========================================================================
+
+    /// Helper: get sorted file names from an SccGroup.
+    fn scc_names(scc: &super::SccGroup) -> Vec<String> {
+        let mut names: Vec<String> = scc
+            .files
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn scc_cycle_is_marked_cyclic() {
+        // A ↔ B
+        let imports = edges(&[("A", &["B"]), ("B", &["A"])]);
+        let layers = build_file_layers_with_sccs(&imports);
+
+        assert_eq!(layers.len(), 1);
+        assert_eq!(layers[0].sccs.len(), 1);
+        assert!(layers[0].sccs[0].is_cyclic);
+        assert_eq!(scc_names(&layers[0].sccs[0]), vec!["A", "B"]);
+    }
+
+    #[test]
+    fn scc_independent_files_are_separate_groups() {
+        // A, B, C independent — same depth, separate non-cyclic SCCs.
+        let imports = edges(&[("A", &[]), ("B", &[]), ("C", &[])]);
+        let layers = build_file_layers_with_sccs(&imports);
+
+        assert_eq!(layers.len(), 1);
+        // Each file is its own SCC.
+        assert_eq!(layers[0].sccs.len(), 3);
+        for scc in &layers[0].sccs {
+            assert!(!scc.is_cyclic);
+            assert_eq!(scc.files.len(), 1);
+        }
+    }
+
+    #[test]
+    fn scc_mixed_layer_cycle_plus_singleton() {
+        // A ↔ B, both → C. Also D → C (independent of the cycle).
+        // Layer 0: C (singleton). Layer 1: {A,B} (cycle) + D (singleton).
+        let imports = edges(&[
+            ("A", &["B", "C"]),
+            ("B", &["A", "C"]),
+            ("C", &[]),
+            ("D", &["C"]),
+        ]);
+        let layers = build_file_layers_with_sccs(&imports);
+
+        assert_eq!(layers.len(), 2);
+        // Layer 0: just C
+        assert_eq!(layers[0].sccs.len(), 1);
+        assert!(!layers[0].sccs[0].is_cyclic);
+
+        // Layer 1: one cyclic SCC {A,B} and one singleton D
+        assert_eq!(layers[1].sccs.len(), 2);
+        let cyclic_scc = layers[1].sccs.iter().find(|s| s.is_cyclic).unwrap();
+        let singleton = layers[1].sccs.iter().find(|s| !s.is_cyclic).unwrap();
+        assert_eq!(scc_names(cyclic_scc), vec!["A", "B"]);
+        assert_eq!(scc_names(singleton), vec!["D"]);
+    }
+
+    #[test]
+    fn scc_self_import_is_cyclic() {
+        // A imports itself.
+        let imports = edges(&[("A", &["A"])]);
+        let layers = build_file_layers_with_sccs(&imports);
+
+        assert_eq!(layers.len(), 1);
+        assert_eq!(layers[0].sccs.len(), 1);
+        assert!(layers[0].sccs[0].is_cyclic);
+        assert_eq!(scc_names(&layers[0].sccs[0]), vec!["A"]);
+    }
+
+    #[test]
+    fn scc_three_file_ring() {
+        // A → B → C → A
+        let imports = edges(&[("A", &["B"]), ("B", &["C"]), ("C", &["A"])]);
+        let layers = build_file_layers_with_sccs(&imports);
+
+        assert_eq!(layers.len(), 1);
+        assert_eq!(layers[0].sccs.len(), 1);
+        assert!(layers[0].sccs[0].is_cyclic);
+        assert_eq!(scc_names(&layers[0].sccs[0]), vec!["A", "B", "C"]);
+    }
+
+    #[test]
+    fn scc_wrapper_matches_flat_output() {
+        // Verify build_file_layers produces the same flat output as before.
+        let imports = edges(&[
+            ("A", &["B", "C"]),
+            ("B", &["A", "C"]),
+            ("C", &[]),
+            ("D", &["C"]),
+        ]);
+        let flat_layers = build_file_layers(&imports);
+        let scc_layers = build_file_layers_with_sccs(&imports);
+
+        assert_eq!(flat_layers.len(), scc_layers.len());
+        for (flat, scc_layer) in flat_layers.iter().zip(scc_layers.iter()) {
+            let flat_sorted = sorted_names(flat);
+            let scc_flat: Vec<PathBuf> = scc_layer.all_files().cloned().collect();
+            let scc_sorted = sorted_names(&scc_flat);
+            assert_eq!(flat_sorted, scc_sorted);
+        }
     }
 }

--- a/crates/lang_check/src/pbt/cyclic.rs
+++ b/crates/lang_check/src/pbt/cyclic.rs
@@ -1,0 +1,182 @@
+// ==============================================================================
+// Property-Based Tests for Cyclic Import Chains
+// ==============================================================================
+//
+// Tests fixpoint iteration over cyclic multi-file imports. Generates random
+// cycle topologies (pairs, rings, mixed acyclic+cyclic) and verifies:
+//   - Crash-freedom: inference never panics for any cycle shape.
+//   - Convergence: fixpoint always terminates within the iteration cap.
+//   - Idempotence: one extra round after convergence produces the same types.
+//   - Acyclic equivalence: non-cycle files produce identical types regardless
+//     of whether fixpoint iteration is enabled.
+
+use proptest::prelude::*;
+
+use super::NixTextStr;
+use crate::tests::check_multifile_fixpoint;
+
+const MAX_FIXPOINT_ROUNDS: usize = 4;
+
+// ==============================================================================
+// Strategies for generating cycle topologies
+// ==============================================================================
+
+/// Generate a two-file cycle where A exports a local field + a field from B,
+/// and B exports a local field + a field from A.
+fn arb_cycle_pair() -> impl Strategy<Value = Vec<(&'static str, String)>> {
+    (arb_prim_value(), arb_prim_value()).prop_map(|(a_val, b_val)| {
+        vec![
+            (
+                "/a.nix",
+                format!("{{ local = {a_val}; fromB = (import /b.nix).local; }}"),
+            ),
+            (
+                "/b.nix",
+                format!("{{ local = {b_val}; fromA = (import /a.nix).local; }}"),
+            ),
+        ]
+    })
+}
+
+/// Generate a three-file ring: A→B→C→A, each with a local field and a
+/// field sourced from its import.
+fn arb_cycle_ring3() -> impl Strategy<Value = Vec<(&'static str, String)>> {
+    (arb_prim_value(), arb_prim_value(), arb_prim_value()).prop_map(|(a_val, b_val, c_val)| {
+        vec![
+            (
+                "/a.nix",
+                format!("{{ local = {a_val}; fromC = (import /c.nix).local; }}"),
+            ),
+            (
+                "/b.nix",
+                format!("{{ local = {b_val}; fromA = (import /a.nix).local; }}"),
+            ),
+            (
+                "/c.nix",
+                format!("{{ local = {c_val}; fromB = (import /b.nix).local; }}"),
+            ),
+        ]
+    })
+}
+
+/// Generate a cycle pair {A,B} plus a non-cyclic file C that both import.
+/// Tests that acyclic deps are unaffected by fixpoint iteration.
+fn arb_cycle_with_acyclic_dep() -> impl Strategy<Value = Vec<(&'static str, String)>> {
+    (arb_prim_value(), arb_prim_value(), arb_prim_value()).prop_map(
+        |(a_val, b_val, c_val)| {
+            vec![
+                (
+                    "/a.nix",
+                    format!(
+                        "{{ local = {a_val}; fromB = (import /b.nix).local; fromC = (import /c.nix).val; }}"
+                    ),
+                ),
+                (
+                    "/b.nix",
+                    format!(
+                        "{{ local = {b_val}; fromA = (import /a.nix).local; fromC = (import /c.nix).val; }}"
+                    ),
+                ),
+                ("/c.nix", format!("{{ val = {c_val}; }}")),
+            ]
+        },
+    )
+}
+
+/// Generate a random primitive value literal.
+fn arb_prim_value() -> impl Strategy<Value = NixTextStr> {
+    prop_oneof![
+        any::<i32>().prop_map(|i| i.to_string()),
+        Just("\"hello\"".to_string()),
+        Just("true".to_string()),
+        Just("null".to_string()),
+    ]
+}
+
+// ==============================================================================
+// Crash-freedom: fixpoint iteration never panics
+// ==============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 128, .. ProptestConfig::default()
+    })]
+
+    /// Two-file cycle with random local values — no panic.
+    #[test]
+    fn cyclic_pair_crash_freedom(files in arb_cycle_pair()) {
+        let refs: Vec<(&str, &str)> = files.iter().map(|(p, s)| (*p, s.as_str())).collect();
+        let _ = check_multifile_fixpoint(&refs, MAX_FIXPOINT_ROUNDS);
+    }
+
+    /// Three-file ring with random local values — no panic.
+    #[test]
+    fn cyclic_ring3_crash_freedom(files in arb_cycle_ring3()) {
+        let refs: Vec<(&str, &str)> = files.iter().map(|(p, s)| (*p, s.as_str())).collect();
+        let _ = check_multifile_fixpoint(&refs, MAX_FIXPOINT_ROUNDS);
+    }
+
+    /// Cycle with acyclic dependency — no panic.
+    #[test]
+    fn cyclic_with_acyclic_dep_crash_freedom(files in arb_cycle_with_acyclic_dep()) {
+        let refs: Vec<(&str, &str)> = files.iter().map(|(p, s)| (*p, s.as_str())).collect();
+        let _ = check_multifile_fixpoint(&refs, MAX_FIXPOINT_ROUNDS);
+    }
+}
+
+// ==============================================================================
+// Convergence: fixpoint terminates within cap
+// ==============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64, .. ProptestConfig::default()
+    })]
+
+    #[test]
+    fn cyclic_pair_converges(files in arb_cycle_pair()) {
+        let refs: Vec<(&str, &str)> = files.iter().map(|(p, s)| (*p, s.as_str())).collect();
+        let (_types, rounds) = check_multifile_fixpoint(&refs, MAX_FIXPOINT_ROUNDS);
+        prop_assert!(
+            rounds <= MAX_FIXPOINT_ROUNDS,
+            "expected convergence within {MAX_FIXPOINT_ROUNDS} rounds, took {rounds}"
+        );
+    }
+
+    #[test]
+    fn cyclic_ring3_converges(files in arb_cycle_ring3()) {
+        let refs: Vec<(&str, &str)> = files.iter().map(|(p, s)| (*p, s.as_str())).collect();
+        let (_types, rounds) = check_multifile_fixpoint(&refs, MAX_FIXPOINT_ROUNDS);
+        prop_assert!(
+            rounds <= MAX_FIXPOINT_ROUNDS,
+            "expected convergence within {MAX_FIXPOINT_ROUNDS} rounds, took {rounds}"
+        );
+    }
+}
+
+// ==============================================================================
+// Idempotence: extra round after convergence produces the same types
+// ==============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64, .. ProptestConfig::default()
+    })]
+
+    #[test]
+    fn cyclic_pair_idempotent(files in arb_cycle_pair()) {
+        let refs: Vec<(&str, &str)> = files.iter().map(|(p, s)| (*p, s.as_str())).collect();
+        let (types_n, _) = check_multifile_fixpoint(&refs, MAX_FIXPOINT_ROUNDS);
+        let (types_n1, _) = check_multifile_fixpoint(&refs, MAX_FIXPOINT_ROUNDS + 1);
+
+        for (path, ty_n) in &types_n {
+            if let Some(ty_n1) = types_n1.get(path) {
+                prop_assert!(
+                    ty_n == ty_n1,
+                    "type changed after convergence for {}: {} vs {}",
+                    path.display(), ty_n, ty_n1
+                );
+            }
+        }
+    }
+}

--- a/crates/lang_check/src/pbt/mod.rs
+++ b/crates/lang_check/src/pbt/mod.rs
@@ -24,6 +24,7 @@
 //   from the arb_prim strategy. Path literals require valid filesystem syntax
 //   and Uri is rarely used.
 
+mod cyclic;
 mod frozen;
 mod partial;
 mod stub_compose;

--- a/crates/lang_check/src/tests.rs
+++ b/crates/lang_check/src/tests.rs
@@ -90,86 +90,11 @@ impl std::fmt::Debug for RootTy {
     }
 }
 
-/// Structural cross-arena equality: compares two types from potentially
-/// different arenas by recursively comparing their OutputTy nodes.
-fn ty_eq(a_arena: &TypeArena, a: TyRef, b_arena: &TypeArena, b: TyRef) -> bool {
-    use rustc_hash::FxHashSet;
-    fn inner(
-        a_arena: &TypeArena,
-        a: TyRef,
-        b_arena: &TypeArena,
-        b: TyRef,
-        visited: &mut FxHashSet<(TyRef, TyRef)>,
-    ) -> bool {
-        if !visited.insert((a, b)) {
-            return true; // cycle — assume equal
-        }
-        let a_node = &a_arena[a];
-        let b_node = &b_arena[b];
-        match (a_node, b_node) {
-            (OutputTy::TyVar(x), OutputTy::TyVar(y)) => x == y,
-            (OutputTy::Primitive(x), OutputTy::Primitive(y)) => x == y,
-            (OutputTy::Bottom, OutputTy::Bottom) | (OutputTy::Top, OutputTy::Top) => true,
-            (OutputTy::List(a_inner), OutputTy::List(b_inner)) => {
-                inner(a_arena, *a_inner, b_arena, *b_inner, visited)
-            }
-            (
-                OutputTy::Lambda {
-                    param: ap,
-                    body: ab,
-                },
-                OutputTy::Lambda {
-                    param: bp,
-                    body: bb,
-                },
-            ) => {
-                inner(a_arena, *ap, b_arena, *bp, visited)
-                    && inner(a_arena, *ab, b_arena, *bb, visited)
-            }
-            (OutputTy::AttrSet(a_attr), OutputTy::AttrSet(b_attr)) => {
-                a_attr.open == b_attr.open
-                    && a_attr.optional_fields == b_attr.optional_fields
-                    && a_attr.fields.len() == b_attr.fields.len()
-                    && a_attr.fields.keys().eq(b_attr.fields.keys())
-                    && a_attr
-                        .fields
-                        .values()
-                        .zip(b_attr.fields.values())
-                        .all(|(av, bv)| inner(a_arena, *av, b_arena, *bv, visited))
-                    && match (a_attr.dyn_ty, b_attr.dyn_ty) {
-                        (Some(ad), Some(bd)) => inner(a_arena, ad, b_arena, bd, visited),
-                        (None, None) => true,
-                        _ => false,
-                    }
-            }
-            (OutputTy::Union(am), OutputTy::Union(bm))
-            | (OutputTy::Intersection(am), OutputTy::Intersection(bm)) => {
-                am.len() == bm.len()
-                    && am
-                        .iter()
-                        .zip(bm.iter())
-                        .all(|(a, b)| inner(a_arena, *a, b_arena, *b, visited))
-            }
-            (OutputTy::Named(an, ai), OutputTy::Named(bn, bi)) => {
-                an == bn && inner(a_arena, *ai, b_arena, *bi, visited)
-            }
-            (OutputTy::Neg(ai), OutputTy::Neg(bi)) => inner(a_arena, *ai, b_arena, *bi, visited),
-            // Extern: follow through to the external arena
-            (OutputTy::Extern(a_owned), _) => {
-                inner(&a_owned.arena, a_owned.root, b_arena, b, visited)
-            }
-            (_, OutputTy::Extern(b_owned)) => {
-                inner(a_arena, a, &b_owned.arena, b_owned.root, visited)
-            }
-            _ => false,
-        }
-    }
-    inner(a_arena, a, b_arena, b, &mut FxHashSet::default())
-}
-
 impl PartialEq for RootTy {
     fn eq(&self, other: &Self) -> bool {
-        ty_eq(&self.arena, self.ty, &other.arena, other.ty)
+        let a = OwnedTy::new(self.arena.clone(), self.ty);
+        let b = OwnedTy::new(other.arena.clone(), other.ty);
+        a.structurally_eq(&b)
     }
 }
 

--- a/crates/lang_check/src/tests.rs
+++ b/crates/lang_check/src/tests.rs
@@ -316,6 +316,80 @@ pub fn get_multifile_result(files: &[(&str, &str)]) -> (RootTy, Vec<crate::impor
     check_multifile(files)
 }
 
+/// Multi-file inference with fixpoint iteration for cyclic imports.
+///
+/// Unlike `check_multifile` which processes deps in a single pass,
+/// this iterates all files until their ephemeral stubs stabilize (or
+/// `max_rounds` is reached). Returns per-file root types and the number
+/// of rounds taken.
+pub fn check_multifile_fixpoint(
+    files: &[(&str, &str)],
+    max_rounds: usize,
+) -> (HashMap<PathBuf, RootTy>, usize) {
+    let (_entry, all_files) = lang_ast::tests::parse_multi_file(files);
+    let aliases = TypeAliasRegistry::default();
+
+    let mut ephemeral_stubs: HashMap<PathBuf, OwnedTy> = HashMap::new();
+    let mut rounds_taken = 0;
+
+    for round in 0..max_rounds {
+        rounds_taken = round + 1;
+        let mut new_stubs: HashMap<PathBuf, OwnedTy> = HashMap::new();
+
+        for &(path_str, _) in files {
+            let file_path = PathBuf::from(path_str);
+            let Some(r) = all_files.get(&file_path) else {
+                continue;
+            };
+            let base_dir = file_path.parent().unwrap_or(Path::new("/"));
+
+            let resolution = resolve_import_types_from_stubs(
+                &r.module,
+                &r.name_res,
+                base_dir,
+                &ephemeral_stubs,
+                Some(&aliases),
+            );
+
+            let file_aliases = crate::load_inline_aliases(Arc::new(aliases.clone()), &r.module);
+            let check = crate::CheckCtx::new(
+                &r.module,
+                &r.name_res,
+                &r.module_indices.binding_expr,
+                file_aliases,
+                resolution.types,
+                Arc::default(),
+            );
+            let (result, _diags, _bailed_out) = check.infer_prog_partial(r.grouped_defs.clone());
+            if let Some(&root_ty) = result.expr_ty_map.get(r.module.entry_expr) {
+                new_stubs.insert(file_path, OwnedTy::new(result.arena.clone(), root_ty));
+            }
+        }
+
+        // Check convergence: all stubs structurally unchanged.
+        if round > 0 {
+            let converged = new_stubs.iter().all(|(path, new_ty)| {
+                ephemeral_stubs
+                    .get(path)
+                    .is_some_and(|old_ty| old_ty.structurally_eq(new_ty))
+            });
+            if converged {
+                ephemeral_stubs = new_stubs;
+                break;
+            }
+        }
+
+        ephemeral_stubs = new_stubs;
+    }
+
+    let result: HashMap<PathBuf, RootTy> = ephemeral_stubs
+        .into_iter()
+        .map(|(path, owned)| (path, RootTy::new(owned.root, Arc::clone(&owned.arena))))
+        .collect();
+
+    (result, rounds_taken)
+}
+
 pub fn get_multifile_root_with_aliases(
     files: &[(&str, &str)],
     aliases: &TypeAliasRegistry,
@@ -1999,8 +2073,8 @@ mod import_tests {
     use std::sync::Arc;
 
     use super::{
-        check_multifile_with_aliases, get_multifile_result, get_multifile_root,
-        get_multifile_root_with_aliases, RootTy,
+        check_multifile_fixpoint, check_multifile_with_aliases, get_multifile_result,
+        get_multifile_root, get_multifile_root_with_aliases, RootTy,
     };
     use crate::aliases::TypeAliasRegistry;
     use crate::imports::resolve_import_types_from_stubs;
@@ -2115,6 +2189,98 @@ mod import_tests {
             matches!(ty.output_ty(), OutputTy::TyVar(_)),
             "cyclic import should degrade to TyVar, got: {ty}"
         );
+    }
+
+    // Fixpoint iteration gives real types across cyclic imports.
+    //
+    // A exports { x = <from B>, z = 42 }, B exports { y = "hello", w = <from A> }.
+    // Single-pass: A.x = ⊤, B.w = ⊤ (no stubs available for the back-edge).
+    // After fixpoint: A.x = string (from B.y), B.w = int (from A.z).
+    #[test]
+    fn import_cyclic_fixpoint_improves_types() {
+        let (types, rounds) = check_multifile_fixpoint(
+            &[
+                ("/a.nix", "{ x = (import /b.nix).y; z = 42; }"),
+                ("/b.nix", "{ y = \"hello\"; w = (import /a.nix).z; }"),
+            ],
+            4,
+        );
+
+        // Should converge in 2-3 rounds.
+        assert!(
+            rounds <= 4,
+            "expected convergence within 4 rounds, took {rounds}"
+        );
+
+        // Check A's type: { x: string, z: int }
+        let a_ty = types
+            .get(&PathBuf::from("/a.nix"))
+            .expect("a.nix should have a type");
+        match a_ty.output_ty() {
+            OutputTy::AttrSet(attr) => {
+                let x_ty = attr.fields.get("x").expect("field x");
+                let z_ty = attr.fields.get("z").expect("field z");
+                assert_eq!(a_ty.child(*x_ty), expected_ty!(String));
+                assert_eq!(a_ty.child(*z_ty), expected_ty!(Int));
+            }
+            _ => panic!("expected attrset for a.nix, got: {a_ty}"),
+        }
+
+        // Check B's type: { y: string, w: int }
+        let b_ty = types
+            .get(&PathBuf::from("/b.nix"))
+            .expect("b.nix should have a type");
+        match b_ty.output_ty() {
+            OutputTy::AttrSet(attr) => {
+                let y_ty = attr.fields.get("y").expect("field y");
+                let w_ty = attr.fields.get("w").expect("field w");
+                assert_eq!(b_ty.child(*y_ty), expected_ty!(String));
+                assert_eq!(b_ty.child(*w_ty), expected_ty!(Int));
+            }
+            _ => panic!("expected attrset for b.nix, got: {b_ty}"),
+        }
+    }
+
+    // Three-file ring: A → B → C → A. Fixpoint resolves all cross-cycle fields.
+    #[test]
+    fn import_cyclic_fixpoint_three_file_ring() {
+        let (types, rounds) = check_multifile_fixpoint(
+            &[
+                ("/a.nix", "{ fromC = (import /c.nix).val; val = 1; }"),
+                ("/b.nix", "{ fromA = (import /a.nix).val; val = \"two\"; }"),
+                ("/c.nix", "{ fromB = (import /b.nix).val; val = true; }"),
+            ],
+            4,
+        );
+
+        assert!(rounds <= 4, "expected convergence, took {rounds}");
+
+        let a_ty = types.get(&PathBuf::from("/a.nix")).unwrap();
+        match a_ty.output_ty() {
+            OutputTy::AttrSet(attr) => {
+                let from_c = attr.fields.get("fromC").expect("field fromC");
+                assert_eq!(a_ty.child(*from_c), expected_ty!(Bool));
+            }
+            _ => panic!("expected attrset for a.nix, got: {a_ty}"),
+        }
+
+        let b_ty = types.get(&PathBuf::from("/b.nix")).unwrap();
+        match b_ty.output_ty() {
+            OutputTy::AttrSet(attr) => {
+                let from_a = attr.fields.get("fromA").expect("field fromA");
+                assert_eq!(b_ty.child(*from_a), expected_ty!(Int));
+            }
+            _ => panic!("expected attrset for b.nix, got: {b_ty}"),
+        }
+
+        let c_ty = types.get(&PathBuf::from("/c.nix")).unwrap();
+        match c_ty.output_ty() {
+            OutputTy::AttrSet(attr) => {
+                let from_b = attr.fields.get("fromB").expect("field fromB");
+                assert_eq!(c_ty.child(*from_b), expected_ty!(String));
+            }
+            _ => panic!("expected attrset for c.nix, got: {c_ty}"),
+        }
     }
 
     // Non-literal import argument (variable) — should stay unconstrained.

--- a/crates/lang_ty/src/arena.rs
+++ b/crates/lang_ty/src/arena.rs
@@ -837,6 +837,112 @@ impl Ord for OwnedTy {
     }
 }
 
+impl OwnedTy {
+    /// Structural cross-arena equality: compares two types from potentially
+    /// different arenas by recursively comparing their OutputTy nodes.
+    ///
+    /// Unlike `PartialEq` (which is identity-based via `Arc::ptr_eq`), this
+    /// compares the actual type structure. Two independently-constructed types
+    /// with the same shape compare as equal.
+    ///
+    /// Used for convergence checks in fixpoint iteration and LSP signature
+    /// change detection.
+    pub fn structurally_eq(&self, other: &Self) -> bool {
+        // Fast path: same arena and same root → identical.
+        if Arc::ptr_eq(&self.arena, &other.arena) && self.root == other.root {
+            return true;
+        }
+        structurally_eq_inner(
+            &self.arena,
+            self.root,
+            &other.arena,
+            other.root,
+            &mut FxHashSet::default(),
+        )
+    }
+}
+
+/// Recursive structural equality with cycle detection.
+///
+/// The `visited` set tracks `(TyRef, TyRef)` pairs already compared to break
+/// cycles (e.g. recursive types via Extern). If we encounter a pair we've
+/// already seen, we assume equality — any structural difference would have
+/// been caught on a different path through the type.
+fn structurally_eq_inner(
+    a_arena: &TypeArena,
+    a: TyRef,
+    b_arena: &TypeArena,
+    b: TyRef,
+    visited: &mut FxHashSet<(TyRef, TyRef)>,
+) -> bool {
+    if !visited.insert((a, b)) {
+        return true; // cycle — assume equal
+    }
+    let a_node = &a_arena[a];
+    let b_node = &b_arena[b];
+    match (a_node, b_node) {
+        (OutputTy::TyVar(x), OutputTy::TyVar(y)) => x == y,
+        (OutputTy::Primitive(x), OutputTy::Primitive(y)) => x == y,
+        (OutputTy::Bottom, OutputTy::Bottom) | (OutputTy::Top, OutputTy::Top) => true,
+        (OutputTy::List(a_inner), OutputTy::List(b_inner)) => {
+            structurally_eq_inner(a_arena, *a_inner, b_arena, *b_inner, visited)
+        }
+        (
+            OutputTy::Lambda {
+                param: ap,
+                body: ab,
+            },
+            OutputTy::Lambda {
+                param: bp,
+                body: bb,
+            },
+        ) => {
+            structurally_eq_inner(a_arena, *ap, b_arena, *bp, visited)
+                && structurally_eq_inner(a_arena, *ab, b_arena, *bb, visited)
+        }
+        (OutputTy::AttrSet(a_attr), OutputTy::AttrSet(b_attr)) => {
+            a_attr.open == b_attr.open
+                && a_attr.optional_fields == b_attr.optional_fields
+                && a_attr.fields.len() == b_attr.fields.len()
+                && a_attr.fields.keys().eq(b_attr.fields.keys())
+                && a_attr
+                    .fields
+                    .values()
+                    .zip(b_attr.fields.values())
+                    .all(|(av, bv)| structurally_eq_inner(a_arena, *av, b_arena, *bv, visited))
+                && match (a_attr.dyn_ty, b_attr.dyn_ty) {
+                    (Some(ad), Some(bd)) => {
+                        structurally_eq_inner(a_arena, ad, b_arena, bd, visited)
+                    }
+                    (None, None) => true,
+                    _ => false,
+                }
+        }
+        (OutputTy::Union(am), OutputTy::Union(bm))
+        | (OutputTy::Intersection(am), OutputTy::Intersection(bm)) => {
+            am.len() == bm.len()
+                && am
+                    .iter()
+                    .zip(bm.iter())
+                    .all(|(a, b)| structurally_eq_inner(a_arena, *a, b_arena, *b, visited))
+        }
+        (OutputTy::Named(an, ai), OutputTy::Named(bn, bi)) => {
+            an == bn && structurally_eq_inner(a_arena, *ai, b_arena, *bi, visited)
+        }
+        (OutputTy::Neg(ai), OutputTy::Neg(bi)) => {
+            structurally_eq_inner(a_arena, *ai, b_arena, *bi, visited)
+        }
+        // Extern: follow through to the external arena.
+        (OutputTy::Extern(a_owned), _) => {
+            structurally_eq_inner(&a_owned.arena, a_owned.root, b_arena, b, visited)
+        }
+        (_, OutputTy::Extern(b_owned)) => {
+            structurally_eq_inner(a_arena, a, &b_owned.arena, b_owned.root, visited)
+        }
+        _ => false,
+    }
+}
+
 impl fmt::Display for OwnedTy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.arena.display(self.root))
@@ -981,5 +1087,182 @@ impl TruncState<'_> {
         buf.push_str(s);
         self.bytes_written += s.len();
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{arc_ty, PrimitiveTy};
+
+    /// Build a simple OwnedTy from a closure that populates an arena.
+    fn make_owned(f: impl FnOnce(&mut TypeArena) -> TyRef) -> OwnedTy {
+        let mut arena = TypeArena::new();
+        let root = f(&mut arena);
+        OwnedTy::new(Arc::new(arena), root)
+    }
+
+    #[test]
+    fn same_primitive_different_arenas() {
+        let a = make_owned(|arena| arena.intern(OutputTy::Primitive(PrimitiveTy::Int)));
+        let b = make_owned(|arena| arena.intern(OutputTy::Primitive(PrimitiveTy::Int)));
+        assert!(!Arc::ptr_eq(&a.arena, &b.arena), "sanity: different arenas");
+        assert!(a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn different_primitives() {
+        let a = make_owned(|arena| arena.intern(OutputTy::Primitive(PrimitiveTy::Int)));
+        let b = make_owned(|arena| arena.intern(OutputTy::Primitive(PrimitiveTy::String)));
+        assert!(!a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn same_arena_fast_path() {
+        let a = make_owned(|arena| arena.intern(OutputTy::Primitive(PrimitiveTy::Int)));
+        // Same arena and root — identity fast path.
+        assert!(a.structurally_eq(&a));
+    }
+
+    #[test]
+    fn lambda_structural_eq() {
+        let a = make_owned(|arena| {
+            let p = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            let b = arena.intern(OutputTy::Primitive(PrimitiveTy::String));
+            arena.intern(OutputTy::Lambda { param: p, body: b })
+        });
+        let b = make_owned(|arena| {
+            let p = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            let b = arena.intern(OutputTy::Primitive(PrimitiveTy::String));
+            arena.intern(OutputTy::Lambda { param: p, body: b })
+        });
+        assert!(a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn lambda_different_body() {
+        let a = make_owned(|arena| {
+            let p = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            let b = arena.intern(OutputTy::Primitive(PrimitiveTy::String));
+            arena.intern(OutputTy::Lambda { param: p, body: b })
+        });
+        let b = make_owned(|arena| {
+            let p = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            let b = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            arena.intern(OutputTy::Lambda { param: p, body: b })
+        });
+        assert!(!a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn attrset_structural_eq() {
+        let a = make_owned(|arena| arc_ty!(arena, { "x" : Int, "y" : String }));
+        let b = make_owned(|arena| arc_ty!(arena, { "x" : Int, "y" : String }));
+        assert!(a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn attrset_different_fields() {
+        let a = make_owned(|arena| arc_ty!(arena, { "x" : Int }));
+        let b = make_owned(|arena| arc_ty!(arena, { "y" : Int }));
+        assert!(!a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn union_structural_eq() {
+        let a = make_owned(|arena| {
+            let members = vec![arc_ty!(arena, Int), arc_ty!(arena, String)];
+            arena.intern(OutputTy::Union(members))
+        });
+        let b = make_owned(|arena| {
+            let members = vec![arc_ty!(arena, Int), arc_ty!(arena, String)];
+            arena.intern(OutputTy::Union(members))
+        });
+        assert!(a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn top_bottom_eq() {
+        let a = make_owned(|arena| arena.intern(OutputTy::Top));
+        let b = make_owned(|arena| arena.intern(OutputTy::Top));
+        assert!(a.structurally_eq(&b));
+
+        let c = make_owned(|arena| arena.intern(OutputTy::Bottom));
+        let d = make_owned(|arena| arena.intern(OutputTy::Bottom));
+        assert!(c.structurally_eq(&d));
+        assert!(!a.structurally_eq(&c));
+    }
+
+    #[test]
+    fn named_structural_eq() {
+        let a = make_owned(|arena| {
+            let inner = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            arena.intern(OutputTy::Named("Foo".into(), inner))
+        });
+        let b = make_owned(|arena| {
+            let inner = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            arena.intern(OutputTy::Named("Foo".into(), inner))
+        });
+        assert!(a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn named_different_name() {
+        let a = make_owned(|arena| {
+            let inner = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            arena.intern(OutputTy::Named("Foo".into(), inner))
+        });
+        let b = make_owned(|arena| {
+            let inner = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            arena.intern(OutputTy::Named("Bar".into(), inner))
+        });
+        assert!(!a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn neg_structural_eq() {
+        let a = make_owned(|arena| {
+            let inner = arena.intern(OutputTy::Primitive(PrimitiveTy::Null));
+            arena.intern(OutputTy::Neg(inner))
+        });
+        let b = make_owned(|arena| {
+            let inner = arena.intern(OutputTy::Primitive(PrimitiveTy::Null));
+            arena.intern(OutputTy::Neg(inner))
+        });
+        assert!(a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn list_structural_eq() {
+        let a = make_owned(|arena| {
+            let inner = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            arena.intern(OutputTy::List(inner))
+        });
+        let b = make_owned(|arena| {
+            let inner = arena.intern(OutputTy::Primitive(PrimitiveTy::Int));
+            arena.intern(OutputTy::List(inner))
+        });
+        assert!(a.structurally_eq(&b));
+    }
+
+    #[test]
+    fn tyvar_structural_eq() {
+        let a = make_owned(|arena| arena.intern(OutputTy::TyVar(0)));
+        let b = make_owned(|arena| arena.intern(OutputTy::TyVar(0)));
+        assert!(a.structurally_eq(&b));
+
+        let c = make_owned(|arena| arena.intern(OutputTy::TyVar(1)));
+        assert!(!a.structurally_eq(&c));
+    }
+
+    #[test]
+    fn extern_unwraps_transparently() {
+        // Build an inner OwnedTy, then wrap it in Extern in another arena.
+        // Structural eq should see through the Extern wrapper.
+        let inner = make_owned(|arena| arena.intern(OutputTy::Primitive(PrimitiveTy::Int)));
+        let wrapped = make_owned(|arena| arena.intern(OutputTy::Extern(inner.clone())));
+        let plain = make_owned(|arena| arena.intern(OutputTy::Primitive(PrimitiveTy::Int)));
+        assert!(wrapped.structurally_eq(&plain));
+        assert!(plain.structurally_eq(&wrapped));
     }
 }

--- a/docs/src/cross-file-types.md
+++ b/docs/src/cross-file-types.md
@@ -89,7 +89,7 @@ Reference the inferred root type of another file:
 data: data.x + 1
 ```
 
-This **does** require inference of the target file. The same cycle detection as regular `import` applies — if A typeof-imports B and B imports A, it's an error.
+This **does** require inference of the target file. The same cycle detection as regular `import` applies — if A typeof-imports B and B imports A, the cycle is detected and the back-edge gets `⊤`. In batch mode (`tix check`), fixpoint iteration resolves many such cycles by re-inferring until types stabilize.
 
 ## Composition
 

--- a/docs/src/diagnostics/e013.md
+++ b/docs/src/diagnostics/e013.md
@@ -3,7 +3,7 @@
 **Severity:** Hint
 
 ```
-imported file `./utils.nix` has not been analyzed -- add it to [project] analyze in
+imported file `./utils.nix` has not been analyzed -- add it to [project] includes in
 tix.toml or open it in the editor
 ```
 
@@ -24,6 +24,6 @@ In most cases, the LSP resolves imports automatically: when you open a file that
 - If the file is generated, add it to the analyze list so it's pre-analyzed:
   ```toml
   [project]
-  analyze = ["lib/*.nix", "utils/*.nix"]
+  includes = ["lib/*.nix", "utils/*.nix"]
   ```
 - Or open the imported file in your editor -- the LSP will analyze it and re-check dependents automatically.

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -116,8 +116,9 @@ In batch mode (`tix check`), files are inferred in topological layers based on t
 
 1. **Import scanning** — during Phase 1 (sequential prepare), each file's import targets are scanned to build a file-level dependency graph.
 2. **SCC computation + layering** — Tarjan's algorithm computes strongly-connected components (SCCs), then a condensation DAG is topologically sorted into layers. Layer 0 contains leaf files (no in-project dependencies); each subsequent layer depends only on prior layers.
-3. **Layer-by-layer inference** — files within each layer run in parallel via rayon. Dependencies from prior layers have their signatures cached in the `InferenceCoordinator`, so imports resolve to real types instead of `⊤`. Files within the same SCC (mutual imports) get `⊤` for intra-SCC imports.
-4. **Reference-counted eviction** — after each layer, signatures whose importers have all been processed are evicted from the cache, keeping memory bounded to the dependency "frontier" rather than the entire project.
+3. **Layer-by-layer inference** — files within each layer run in parallel via rayon. Dependencies from prior layers have their signatures cached in the `InferenceCoordinator`, so imports resolve to real types instead of `⊤`.
+4. **Fixpoint iteration for cyclic SCCs** — files in non-trivial SCCs (mutual imports) are re-inferred until their signatures stabilize (up to 4 rounds). In round 1, intra-SCC imports get `⊤`; in subsequent rounds, they get the prior round's inferred types. This gives real types across cycle edges. Convergence is checked via structural equality of `OwnedTy` signatures.
+5. **Reference-counted eviction** — after each layer, signatures whose importers have all been processed are evicted from the cache, keeping memory bounded to the dependency "frontier" rather than the entire project.
 
 ## Stub integration
 


### PR DESCRIPTION
Before in tix check if there was a cylic file import, the files in the cycle would be in the same SCC group. Tix would treat each import as "any" and move on. 

Now we do a fixed point of inference on the group until it converges or does 4 iterations. 4 was picked arbitrarily, i think for most nix code it should work fine